### PR TITLE
Add timeout for node execution

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,5 @@
 codecov:
-  require_ci_to_pass: yes
+  require_ci_to_pass: true
 
 # ignore files in demo package
 ignore:
@@ -12,5 +12,8 @@ coverage:
   status:
     project:
       default:
-        target: 70%    # the required coverage value
-        threshold: 1%  # the leniency in hitting the target
+        target: auto
+        threshold: 2%  # project coverage can drop
+    patch:
+      default:
+        target: 70%    # required diff coverage value

--- a/src/main/java/demo/Demo.java
+++ b/src/main/java/demo/Demo.java
@@ -14,10 +14,12 @@ import org.opensearch.client.Client;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.io.PathUtils;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.flowframework.model.Template;
 import org.opensearch.flowframework.workflow.ProcessNode;
 import org.opensearch.flowframework.workflow.WorkflowProcessSorter;
 import org.opensearch.flowframework.workflow.WorkflowStepFactory;
+import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -26,8 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -36,6 +37,8 @@ import java.util.stream.Collectors;
 public class Demo {
 
     private static final Logger logger = LogManager.getLogger(Demo.class);
+
+    private Demo() {}
 
     /**
      * Demonstrate parsing a JSON graph.
@@ -55,8 +58,9 @@ public class Demo {
         }
         Client client = new NodeClient(null, null);
         WorkflowStepFactory factory = WorkflowStepFactory.create(client);
-        ExecutorService executor = Executors.newFixedThreadPool(10);
-        WorkflowProcessSorter.create(factory, executor);
+
+        ThreadPool threadPool = new ThreadPool(Settings.EMPTY);
+        WorkflowProcessSorter.create(factory, threadPool);
 
         logger.info("Parsing graph to sequence...");
         Template t = Template.parse(json);
@@ -80,6 +84,6 @@ public class Demo {
         }
         futureList.forEach(CompletableFuture::join);
         logger.info("All done!");
-        executor.shutdown();
+        ThreadPool.terminate(threadPool, 500, TimeUnit.MILLISECONDS);
     }
 }

--- a/src/main/java/demo/Demo.java
+++ b/src/main/java/demo/Demo.java
@@ -57,14 +57,14 @@ public class Demo {
             return;
         }
         Client client = new NodeClient(null, null);
-        WorkflowStepFactory factory = WorkflowStepFactory.create(client);
+        WorkflowStepFactory factory = new WorkflowStepFactory(client);
 
         ThreadPool threadPool = new ThreadPool(Settings.EMPTY);
-        WorkflowProcessSorter.create(factory, threadPool);
+        WorkflowProcessSorter workflowProcessSorter = new WorkflowProcessSorter(factory, threadPool);
 
         logger.info("Parsing graph to sequence...");
         Template t = Template.parse(json);
-        List<ProcessNode> processSequence = WorkflowProcessSorter.get().sortProcessNodes(t.workflows().get("demo"));
+        List<ProcessNode> processSequence = workflowProcessSorter.sortProcessNodes(t.workflows().get("demo"));
         List<CompletableFuture<?>> futureList = new ArrayList<>();
 
         for (ProcessNode n : processSequence) {

--- a/src/main/java/demo/TemplateParseDemo.java
+++ b/src/main/java/demo/TemplateParseDemo.java
@@ -53,9 +53,9 @@ public class TemplateParseDemo {
             return;
         }
         Client client = new NodeClient(null, null);
-        WorkflowStepFactory factory = WorkflowStepFactory.create(client);
+        WorkflowStepFactory factory = new WorkflowStepFactory(client);
         ThreadPool threadPool = new ThreadPool(Settings.EMPTY);
-        WorkflowProcessSorter.create(factory, threadPool);
+        WorkflowProcessSorter workflowProcessSorter = new WorkflowProcessSorter(factory, threadPool);
 
         Template t = Template.parse(json);
 
@@ -64,7 +64,7 @@ public class TemplateParseDemo {
 
         for (Entry<String, Workflow> e : t.workflows().entrySet()) {
             logger.info("Parsing {} workflow.", e.getKey());
-            WorkflowProcessSorter.get().sortProcessNodes(e.getValue());
+            workflowProcessSorter.sortProcessNodes(e.getValue());
         }
         ThreadPool.terminate(threadPool, 500, TimeUnit.MILLISECONDS);
     }

--- a/src/main/java/demo/TemplateParseDemo.java
+++ b/src/main/java/demo/TemplateParseDemo.java
@@ -14,16 +14,18 @@ import org.opensearch.client.Client;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.io.PathUtils;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.flowframework.model.Template;
 import org.opensearch.flowframework.model.Workflow;
 import org.opensearch.flowframework.workflow.WorkflowProcessSorter;
 import org.opensearch.flowframework.workflow.WorkflowStepFactory;
+import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Map.Entry;
-import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Demo class exercising {@link WorkflowProcessSorter}. This will be moved to a unit test.
@@ -31,6 +33,8 @@ import java.util.concurrent.Executors;
 public class TemplateParseDemo {
 
     private static final Logger logger = LogManager.getLogger(TemplateParseDemo.class);
+
+    private TemplateParseDemo() {}
 
     /**
      * Demonstrate parsing a JSON graph.
@@ -50,7 +54,8 @@ public class TemplateParseDemo {
         }
         Client client = new NodeClient(null, null);
         WorkflowStepFactory factory = WorkflowStepFactory.create(client);
-        WorkflowProcessSorter.create(factory, Executors.newFixedThreadPool(10));
+        ThreadPool threadPool = new ThreadPool(Settings.EMPTY);
+        WorkflowProcessSorter.create(factory, threadPool);
 
         Template t = Template.parse(json);
 
@@ -61,5 +66,6 @@ public class TemplateParseDemo {
             logger.info("Parsing {} workflow.", e.getKey());
             WorkflowProcessSorter.get().sortProcessNodes(e.getValue());
         }
+        ThreadPool.terminate(threadPool, 500, TimeUnit.MILLISECONDS);
     }
 }

--- a/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
+++ b/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
@@ -32,6 +32,11 @@ import java.util.function.Supplier;
  */
 public class FlowFrameworkPlugin extends Plugin {
 
+    /**
+     * Instantiate this plugin.
+     */
+    public FlowFrameworkPlugin() {}
+
     @Override
     public Collection<Object> createComponents(
         Client client,
@@ -47,7 +52,7 @@ public class FlowFrameworkPlugin extends Plugin {
         Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
         WorkflowStepFactory workflowStepFactory = WorkflowStepFactory.create(client);
-        WorkflowProcessSorter workflowProcessSorter = WorkflowProcessSorter.create(workflowStepFactory, threadPool.generic());
+        WorkflowProcessSorter workflowProcessSorter = WorkflowProcessSorter.create(workflowStepFactory, threadPool);
 
         return ImmutableList.of(workflowStepFactory, workflowProcessSorter);
     }

--- a/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
+++ b/src/main/java/org/opensearch/flowframework/FlowFrameworkPlugin.java
@@ -51,8 +51,8 @@ public class FlowFrameworkPlugin extends Plugin {
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
-        WorkflowStepFactory workflowStepFactory = WorkflowStepFactory.create(client);
-        WorkflowProcessSorter workflowProcessSorter = WorkflowProcessSorter.create(workflowStepFactory, threadPool);
+        WorkflowStepFactory workflowStepFactory = new WorkflowStepFactory(client);
+        WorkflowProcessSorter workflowProcessSorter = new WorkflowProcessSorter(workflowStepFactory, threadPool);
 
         return ImmutableList.of(workflowStepFactory, workflowProcessSorter);
     }

--- a/src/main/java/org/opensearch/flowframework/model/WorkflowNode.java
+++ b/src/main/java/org/opensearch/flowframework/model/WorkflowNode.java
@@ -41,6 +41,10 @@ public class WorkflowNode implements ToXContentObject {
     public static final String INPUTS_FIELD = "inputs";
     /** The field defining processors in the inputs for search and ingest pipelines */
     public static final String PROCESSORS_FIELD = "processors";
+    /** The field defining the timeout value for this node */
+    public static final String NODE_TIMEOUT_FIELD = "node_timeout";
+    /** The default timeout value if the template doesn't override it */
+    public static final String NODE_TIMEOUT_DEFAULT_VALUE = "10s";
 
     private final String id; // unique id
     private final String type; // maps to a WorkflowStep

--- a/src/main/java/org/opensearch/flowframework/workflow/ProcessNode.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ProcessNode.java
@@ -22,8 +22,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 /**
- * Representation of a process node in a workflow graph. Tracks predecessor nodes which must be completed before it can
- * start execution.
+ * Representation of a process node in a workflow graph.
+ * Tracks predecessor nodes which must be completed before it can start execution.
  */
 public class ProcessNode {
 
@@ -41,12 +41,12 @@ public class ProcessNode {
     /**
      * Create this node linked to its executing process, including input data and any predecessor nodes.
      *
-     * @param id           A string identifying the workflow step
+     * @param id A string identifying the workflow step
      * @param workflowStep A java class implementing {@link WorkflowStep} to be executed when it's this node's turn.
-     * @param input        Input required by the node encoded in a {@link WorkflowData} instance.
+     * @param input Input required by the node encoded in a {@link WorkflowData} instance.
      * @param predecessors Nodes preceding this one in the workflow
-     * @param threadPool   The OpenSearch thread pool
-     * @param nodeTimeout  The timeout value for executing on this node
+     * @param threadPool The OpenSearch thread pool
+     * @param nodeTimeout The timeout value for executing on this node
      */
     public ProcessNode(
         String id,
@@ -66,7 +66,6 @@ public class ProcessNode {
 
     /**
      * Returns the node's id.
-     *
      * @return the node id.
      */
     public String id() {
@@ -75,7 +74,6 @@ public class ProcessNode {
 
     /**
      * Returns the node's workflow implementation.
-     *
      * @return the workflow step
      */
     public WorkflowStep workflowStep() {
@@ -84,7 +82,6 @@ public class ProcessNode {
 
     /**
      * Returns the input data for this node.
-     *
      * @return the input data
      */
     public WorkflowData input() {
@@ -92,32 +89,33 @@ public class ProcessNode {
     }
 
     /**
-     * Returns a {@link CompletableFuture} if this process is executing. Relies on the node having been sorted and
-     * executed in an order such that all predecessor nodes have begun execution first (and thus populated this value).
+     * Returns a {@link CompletableFuture} if this process is executing.
+     * Relies on the node having been sorted and executed in an order such that all predecessor nodes have begun execution first (and thus populated this value).
      *
-     * @return A future indicating the processing state of this node. Returns {@code null} if it has not begun
-     *         executing, should not happen if a workflow is sorted and executed topologically.
+     * @return A future indicating the processing state of this node.
+     * Returns {@code null} if it has not begun executing, should not happen if a workflow is sorted and executed topologically.
      */
     public CompletableFuture<WorkflowData> future() {
         return future;
     }
 
     /**
-     * Returns the predecessors of this node in the workflow. The predecessor's {@link #future()} must complete before
-     * execution begins on this node.
+     * Returns the predecessors of this node in the workflow.
+     * The predecessor's {@link #future()} must complete before execution begins on this node.
      *
-     * @return a set of predecessor nodes, if any. At least one node in the graph must have no predecessors and serve as
-     *         a start node.
+     * @return a set of predecessor nodes, if any.
+     * At least one node in the graph must have no predecessors and serve as a start node.
      */
     public List<ProcessNode> predecessors() {
         return predecessors;
     }
 
     /**
-     * Execute this node in the sequence. Initializes the node's {@link CompletableFuture} and completes it when the
-     * process completes.
+     * Execute this node in the sequence.
+     * Initializes the node's {@link CompletableFuture} and completes it when the process completes.
      *
-     * @return this node's future. This is returned immediately, while process execution continues asynchronously.
+     * @return this node's future.
+     * This is returned immediately, while process execution continues asynchronously.
      */
     public CompletableFuture<WorkflowData> execute() {
         if (this.future.isDone()) {

--- a/src/main/java/org/opensearch/flowframework/workflow/ProcessNode.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/ProcessNode.java
@@ -11,19 +11,19 @@ package org.opensearch.flowframework.workflow;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.common.util.concurrent.FutureUtils;
+import org.opensearch.threadpool.Scheduler.ScheduledCancellable;
+import org.opensearch.threadpool.ThreadPool;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 /**
- * Representation of a process node in a workflow graph.  Tracks predecessor nodes which must be completed before it can start execution.
+ * Representation of a process node in a workflow graph. Tracks predecessor nodes which must be completed before it can
+ * start execution.
  */
 public class ProcessNode {
 
@@ -33,7 +33,7 @@ public class ProcessNode {
     private final WorkflowStep workflowStep;
     private final WorkflowData input;
     private final List<ProcessNode> predecessors;
-    private final Executor executor;
+    private final ThreadPool threadPool;
     private final TimeValue nodeTimeout;
 
     private final CompletableFuture<WorkflowData> future = new CompletableFuture<>();
@@ -41,31 +41,32 @@ public class ProcessNode {
     /**
      * Create this node linked to its executing process, including input data and any predecessor nodes.
      *
-     * @param id A string identifying the workflow step
+     * @param id           A string identifying the workflow step
      * @param workflowStep A java class implementing {@link WorkflowStep} to be executed when it's this node's turn.
-     * @param input Input required by the node encoded in a {@link WorkflowData} instance.
+     * @param input        Input required by the node encoded in a {@link WorkflowData} instance.
      * @param predecessors Nodes preceding this one in the workflow
-     * @param executor The OpenSearch thread pool
-     * @param nodeTimeout The timeout value for executing on this node
+     * @param threadPool   The OpenSearch thread pool
+     * @param nodeTimeout  The timeout value for executing on this node
      */
     public ProcessNode(
         String id,
         WorkflowStep workflowStep,
         WorkflowData input,
         List<ProcessNode> predecessors,
-        Executor executor,
+        ThreadPool threadPool,
         TimeValue nodeTimeout
     ) {
         this.id = id;
         this.workflowStep = workflowStep;
         this.input = input;
         this.predecessors = predecessors;
-        this.executor = executor;
+        this.threadPool = threadPool;
         this.nodeTimeout = nodeTimeout;
     }
 
     /**
      * Returns the node's id.
+     *
      * @return the node id.
      */
     public String id() {
@@ -74,6 +75,7 @@ public class ProcessNode {
 
     /**
      * Returns the node's workflow implementation.
+     *
      * @return the workflow step
      */
     public WorkflowStep workflowStep() {
@@ -82,6 +84,7 @@ public class ProcessNode {
 
     /**
      * Returns the input data for this node.
+     *
      * @return the input data
      */
     public WorkflowData input() {
@@ -89,28 +92,30 @@ public class ProcessNode {
     }
 
     /**
-     * Returns a {@link CompletableFuture} if this process is executing.
-     * Relies on the node having been sorted and executed in an order such that all predecessor nodes have begun execution first (and thus populated this value).
+     * Returns a {@link CompletableFuture} if this process is executing. Relies on the node having been sorted and
+     * executed in an order such that all predecessor nodes have begun execution first (and thus populated this value).
      *
-     * @return A future indicating the processing state of this node.
-     * Returns {@code null} if it has not begun executing, should not happen if a workflow is sorted and executed topologically.
+     * @return A future indicating the processing state of this node. Returns {@code null} if it has not begun
+     *         executing, should not happen if a workflow is sorted and executed topologically.
      */
     public CompletableFuture<WorkflowData> future() {
         return future;
     }
 
     /**
-     * Returns the predecessors of this node in the workflow.
-     * The predecessor's {@link #future()} must complete before execution begins on this node.
+     * Returns the predecessors of this node in the workflow. The predecessor's {@link #future()} must complete before
+     * execution begins on this node.
      *
-     * @return a set of predecessor nodes, if any.  At least one node in the graph must have no predecessors and serve as a start node.
+     * @return a set of predecessor nodes, if any. At least one node in the graph must have no predecessors and serve as
+     *         a start node.
      */
     public List<ProcessNode> predecessors() {
         return predecessors;
     }
 
     /**
-     * Execute this node in the sequence. Initializes the node's {@link CompletableFuture} and completes it when the process completes.
+     * Execute this node in the sequence. Initializes the node's {@link CompletableFuture} and completes it when the
+     * process completes.
      *
      * @return this node's future. This is returned immediately, while process execution continues asynchronously.
      */
@@ -134,25 +139,26 @@ public class ProcessNode {
                 }
             }
             try {
-                CompletableFuture<Void> delayFuture = null;
+                ScheduledCancellable delayExec = null;
                 if (this.nodeTimeout.compareTo(TimeValue.ZERO) > 0) {
-                    Executor timeoutExec = CompletableFuture.delayedExecutor(this.nodeTimeout.nanos(), TimeUnit.NANOSECONDS, executor);
-                    delayFuture = CompletableFuture.runAsync(() -> {
+                    delayExec = threadPool.schedule(() -> {
                         future.completeExceptionally(new TimeoutException("Execute timed out for " + this.id));
                         // If completed normally the above will be a no-op
                         if (future.isCompletedExceptionally()) {
                             logger.info(">>> Timed out {}.", this.id);
                         }
-                    }, timeoutExec);
+                    }, this.nodeTimeout, ThreadPool.Names.GENERIC);
+                    // TODO: improve use of thread pool beyond generic
+                    // https://github.com/opensearch-project/opensearch-ai-flow-framework/issues/61
                 }
                 CompletableFuture<WorkflowData> stepFuture = this.workflowStep.execute(input);
                 future.complete(stepFuture.get()); // If completed exceptionally, this is a NOOP
+                delayExec.cancel();
                 logger.info(">>> Finished {}.", this.id);
-                FutureUtils.cancel(delayFuture);
             } catch (InterruptedException | ExecutionException e) {
                 handleException(e);
             }
-        }, executor);
+        }, threadPool.generic());
         return this.future;
     }
 

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
@@ -34,45 +34,22 @@ import static org.opensearch.flowframework.model.WorkflowNode.NODE_TIMEOUT_DEFAU
 import static org.opensearch.flowframework.model.WorkflowNode.NODE_TIMEOUT_FIELD;
 
 /**
- * Utility class converting a workflow of nodes and edges into a topologically sorted list of Process Nodes.
+ * Converts a workflow of nodes and edges into a topologically sorted list of Process Nodes.
  */
 public class WorkflowProcessSorter {
 
     private static final Logger logger = LogManager.getLogger(WorkflowProcessSorter.class);
 
-    private static WorkflowProcessSorter instance = null;
-
     private WorkflowStepFactory workflowStepFactory;
     private ThreadPool threadPool;
 
     /**
-     * Create the singleton instance of this class. Throws an {@link IllegalStateException} if already created.
+     * Instantiate this class.
      *
-     * @param workflowStepFactory The singleton instance of {@link WorkflowStepFactory}
-     * @param threadPool The Thread Pool to send to Process Nodes
-     * @return The created instance
+     * @param workflowStepFactory The factory which matches template step types to instances.
+     * @param threadPool The OpenSearch Thread pool to pass to process nodes.
      */
-    public static synchronized WorkflowProcessSorter create(WorkflowStepFactory workflowStepFactory, ThreadPool threadPool) {
-        if (instance != null) {
-            throw new IllegalStateException("This class was already created.");
-        }
-        instance = new WorkflowProcessSorter(workflowStepFactory, threadPool);
-        return instance;
-    }
-
-    /**
-     * Gets the singleton instance of this class. Throws an {@link IllegalStateException} if not yet created.
-     *
-     * @return The created instance
-     */
-    public static synchronized WorkflowProcessSorter get() {
-        if (instance == null) {
-            throw new IllegalStateException("This factory has not yet been created.");
-        }
-        return instance;
-    }
-
-    private WorkflowProcessSorter(WorkflowStepFactory workflowStepFactory, ThreadPool threadPool) {
+    public WorkflowProcessSorter(WorkflowStepFactory workflowStepFactory, ThreadPool threadPool) {
         this.workflowStepFactory = workflowStepFactory;
         this.threadPool = threadPool;
     }

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowProcessSorter.java
@@ -49,7 +49,7 @@ public class WorkflowProcessSorter {
      * Create the singleton instance of this class. Throws an {@link IllegalStateException} if already created.
      *
      * @param workflowStepFactory The singleton instance of {@link WorkflowStepFactory}
-     * @param threadPool          A thread executor
+     * @param threadPool The Thread Pool to send to Process Nodes
      * @return The created instance
      */
     public static synchronized WorkflowProcessSorter create(WorkflowStepFactory workflowStepFactory, ThreadPool threadPool) {

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStep.java
@@ -25,7 +25,6 @@ public interface WorkflowStep {
 
     /**
      * Gets the name of the workflow step.
-     *
      * @return the name of this workflow step.
      */
     String getName();

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStep.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStep.java
@@ -24,6 +24,7 @@ public interface WorkflowStep {
     CompletableFuture<WorkflowData> execute(List<WorkflowData> data);
 
     /**
+     * Gets the name of the workflow step.
      *
      * @return the name of this workflow step.
      */

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
@@ -62,7 +62,7 @@ public class WorkflowStepFactory {
 
         // TODO: These are from the demo class as placeholders, remove when demos are deleted
         stepMap.put("demo_delay_3", new DemoWorkflowStep(3000));
-        stepMap.put("demo_delay_5", new DemoWorkflowStep(3000));
+        stepMap.put("demo_delay_5", new DemoWorkflowStep(5000));
 
         // Use as a default until all the actual implementations are ready
         stepMap.put("placeholder", new WorkflowStep() {

--- a/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
+++ b/src/main/java/org/opensearch/flowframework/workflow/WorkflowStepFactory.java
@@ -22,37 +22,14 @@ import demo.DemoWorkflowStep;
  */
 public class WorkflowStepFactory {
 
-    private static WorkflowStepFactory instance = null;
-
     private final Map<String, WorkflowStep> stepMap = new HashMap<>();
 
     /**
-     * Create the singleton instance of this class. Throws an {@link IllegalStateException} if already created.
+     * Instantiate this class.
      *
      * @param client The OpenSearch client steps can use
-     * @return The created instance
      */
-    public static synchronized WorkflowStepFactory create(Client client) {
-        if (instance != null) {
-            throw new IllegalStateException("This factory was already created.");
-        }
-        instance = new WorkflowStepFactory(client);
-        return instance;
-    }
-
-    /**
-     * Gets the singleton instance of this class. Throws an {@link IllegalStateException} if not yet created.
-     *
-     * @return The created instance
-     */
-    public static synchronized WorkflowStepFactory get() {
-        if (instance == null) {
-            throw new IllegalStateException("This factory has not yet been created.");
-        }
-        return instance;
-    }
-
-    private WorkflowStepFactory(Client client) {
+    public WorkflowStepFactory(Client client) {
         populateMap(client);
     }
 

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkPluginTests.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkPluginTests.java
@@ -8,8 +8,40 @@
  */
 package org.opensearch.flowframework;
 
+import org.opensearch.client.AdminClient;
+import org.opensearch.client.Client;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class FlowFrameworkPluginTests extends OpenSearchTestCase {
-    // Add unit tests for your plugin
+
+    private Client client;
+    private ThreadPool threadPool;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        client = mock(Client.class);
+        when(client.admin()).thenReturn(mock(AdminClient.class));
+        threadPool = new TestThreadPool(FlowFrameworkPluginTests.class.getName());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        ThreadPool.terminate(threadPool, 500, TimeUnit.MILLISECONDS);
+        super.tearDown();
+    }
+
+    public void testPlugin() throws IOException {
+        try (FlowFrameworkPlugin ffp = new FlowFrameworkPlugin()) {
+            assertEquals(2, ffp.createComponents(client, null, threadPool, null, null, null, null, null, null, null, null).size());
+        }
+    }
 }

--- a/src/test/java/org/opensearch/flowframework/model/TemplateTestJsonUtil.java
+++ b/src/test/java/org/opensearch/flowframework/model/TemplateTestJsonUtil.java
@@ -27,7 +27,29 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 public class TemplateTestJsonUtil {
 
     public static String node(String id) {
-        return "{\"" + WorkflowNode.ID_FIELD + "\": \"" + id + "\", \"" + WorkflowNode.TYPE_FIELD + "\": \"" + "placeholder" + "\"}";
+        return nodeWithType(id, "placeholder");
+    }
+
+    public static String nodeWithType(String id, String type) {
+        return "{\"" + WorkflowNode.ID_FIELD + "\": \"" + id + "\", \"" + WorkflowNode.TYPE_FIELD + "\": \"" + type + "\"}";
+    }
+
+    public static String nodeWithTypeAndTimeout(String id, String type, String timeout) {
+        return "{\""
+            + WorkflowNode.ID_FIELD
+            + "\": \""
+            + id
+            + "\", \""
+            + WorkflowNode.TYPE_FIELD
+            + "\": \""
+            + type
+            + "\", \""
+            + WorkflowNode.INPUTS_FIELD
+            + "\": {\""
+            + WorkflowNode.NODE_TIMEOUT_FIELD
+            + "\": \""
+            + timeout
+            + "\"}}";
     }
 
     public static String edge(String sourceId, String destId) {

--- a/src/test/java/org/opensearch/flowframework/workflow/ProcessNodeTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/ProcessNodeTests.java
@@ -8,29 +8,45 @@
  */
 package org.opensearch.flowframework.workflow;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.test.OpenSearchTestCase;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class ProcessNodeTests extends OpenSearchTestCase {
 
-    private ExecutorService executor;
+    private static ExecutorService executor;
 
-    @Before
-    public void setup() {
+    @BeforeClass
+    public static void setup() {
         executor = Executors.newFixedThreadPool(10);
     }
 
-    @After
-    public void cleanup() {
+    @AfterClass
+    public static void cleanup() {
         executor.shutdown();
+        try {
+            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+                executor.awaitTermination(5, TimeUnit.SECONDS);
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
     }
 
     public void testNode() throws InterruptedException, ExecutionException {
@@ -46,7 +62,7 @@ public class ProcessNodeTests extends OpenSearchTestCase {
             public String getName() {
                 return "test";
             }
-        }, WorkflowData.EMPTY, Collections.emptyList(), executor);
+        }, WorkflowData.EMPTY, Collections.emptyList(), executor, TimeValue.ZERO);
         assertEquals("A", nodeA.id());
         assertEquals("test", nodeA.workflowStep().getName());
         assertEquals(WorkflowData.EMPTY, nodeA.input());
@@ -56,5 +72,33 @@ public class ProcessNodeTests extends OpenSearchTestCase {
         CompletableFuture<WorkflowData> f = nodeA.execute();
         assertEquals(f, nodeA.future());
         assertEquals(WorkflowData.EMPTY, f.get());
+    }
+
+    public void testNodeTimeout() throws InterruptedException, ExecutionException {
+        ProcessNode nodeZ = new ProcessNode("Zzz", new WorkflowStep() {
+            @Override
+            public CompletableFuture<WorkflowData> execute(List<WorkflowData> data) {
+                CompletableFuture<WorkflowData> future = new CompletableFuture<>();
+                CompletableFuture.delayedExecutor(250, TimeUnit.MILLISECONDS, executor).execute(() -> future.complete(WorkflowData.EMPTY));
+                return future;
+            }
+
+            @Override
+            public String getName() {
+                return "sleepy";
+            }
+        }, WorkflowData.EMPTY, Collections.emptyList(), executor, TimeValue.timeValueMillis(100));
+        assertEquals("Zzz", nodeZ.id());
+        assertEquals("sleepy", nodeZ.workflowStep().getName());
+        assertEquals(WorkflowData.EMPTY, nodeZ.input());
+        assertEquals(Collections.emptyList(), nodeZ.predecessors());
+        assertEquals("Zzz", nodeZ.toString());
+
+        CompletableFuture<WorkflowData> f = nodeZ.execute();
+        CompletionException exception = assertThrows(CompletionException.class, () -> f.join());
+        assertTrue(f.isCompletedExceptionally());
+        assertEquals(TimeoutException.class, exception.getCause().getClass());
+
+        assertThrows(IllegalStateException.class, () -> nodeZ.execute());
     }
 }

--- a/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
+++ b/src/test/java/org/opensearch/flowframework/workflow/WorkflowProcessSorterTests.java
@@ -54,8 +54,8 @@ public class WorkflowProcessSorterTests extends OpenSearchTestCase {
         when(client.admin()).thenReturn(adminClient);
 
         testThreadPool = new TestThreadPool(WorkflowProcessSorterTests.class.getName());
-        WorkflowStepFactory factory = WorkflowStepFactory.create(client);
-        workflowProcessSorter = WorkflowProcessSorter.create(factory, testThreadPool);
+        WorkflowStepFactory factory = new WorkflowStepFactory(client);
+        workflowProcessSorter = new WorkflowProcessSorter(factory, testThreadPool);
     }
 
     @AfterClass

--- a/src/test/resources/template/finaltemplate.json
+++ b/src/test/resources/template/finaltemplate.json
@@ -25,7 +25,8 @@
                     "type": "create_index",
                     "inputs": {
                         "name": "user_inputs.index_name",
-                        "settings": "user_inputs.index_settings"
+                        "settings": "user_inputs.index_settings",
+                        "node_timeout": "10s"
                     }
                 },
                 {
@@ -41,7 +42,8 @@
                                 "input_field": "text_passage",
                                 "output_field": "text_embedding"
                             }
-                        }]
+                        }],
+                        "node_timeout": "10s"
                     }
                 }
             ],
@@ -60,7 +62,8 @@
                 "inputs": {
                     "index": "user_inputs.index_name",
                     "ingest_pipeline": "my-ingest-pipeline",
-                    "document": "user_params.document"
+                    "document": "user_params.document",
+                    "node_timeout": "10s"
                 }
             }]
         },
@@ -73,7 +76,8 @@
                     "type": "transform_query",
                     "inputs": {
                         "template": "neural-search-template-1",
-                        "plaintext": "user_params.plaintext"
+                        "plaintext": "user_params.plaintext",
+                        "node_timeout": "10s"
                     }
                 },
                 {
@@ -83,7 +87,8 @@
                         "index": "user_inputs.index_name",
                         "query": "{{output-from-prev-step}}.query",
                         "search_request_processors": [],
-                        "search_response_processors": []
+                        "search_response_processors": [],
+                        "node_timeout": "10s"
                     }
                 }
             ],


### PR DESCRIPTION
### Description

Adds a timeout setting for each node's processing of the Workflow step's `execute()` method in the `ProcessNode`.

Some steps should complete quickly (e.g., create index) while others may take more time to complete (upload/deploy model).

Presently implementing that in the user template (See #45 where I proposed this and nobody objected), with a default to 10s if omitted.
 - It is not required to be entered in the template. It's an option.
 - This location is temporary, it can be moved anywhere else with a simple code change. See #67 for one proposal where to move it.
 - Open to any other ideas, but...
 - I want to keep functionality similar to existing REST APIs where users can add a "timeout" param.  We have multiple APIs and need to enable multiple timeouts that the user can change.
 - Selecting a timeout of 0 means no timeout.

I considered a global timeout, but decided against it as the "sum of node timeouts" effectively enforces that.  I also considered a timeout by workflow type, tied to the default timeouts for their implemented APIs.

Other changes needed along the way:
 - Switched from executor to thread pool to pass around from create components and used for scheduled execution
 - Got rid of test thread leaks by using thread pool properly
 - Added test for plugin class
 - Got rid of singleton step factory and  process sorter classes since they didn't play nice with tests (a singleton is still injected when we eventually get to transport actions)
 - Added missing javadocs creating warnings for JDK18+

### Issues Resolved

Fixes #42 properly
Fixes #45 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
