### PR TITLE
Run integ tests in parallel with build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,4 @@
-name: Build and Test Plugin
+name: CI
 
 on:
   push:
@@ -9,14 +9,12 @@ on:
 
 jobs:
   spotless:
-    if: github.repository == 'opensearch-project/opensearch-ai-flow-framework'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Spotless Check
         run: ./gradlew spotlessCheck
   javadoc:
-    if: github.repository == 'opensearch-project/opensearch-ai-flow-framework'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,19 +23,14 @@ jobs:
       - name: Javadoc Check
         run: ./gradlew javadoc
   build:
+    if: github.repository == 'opensearch-project/opensearch-ai-flow-framework'
     needs: [spotless, javadoc]
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-          - macOS-latest
-          - windows-latest
-        java:
-          - 17
-    name: Build and Test Plugin Template
-    if: github.repository == 'opensearch-project/opensearch-ai-flow-framework'
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        java: [11, 17, 20]
+    name: Test JDK${{ matrix.java }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK ${{ matrix.java }}
@@ -47,9 +40,28 @@ jobs:
         distribution: temurin
     - name: Build and Run Tests
       run: |
-          ./gradlew check
+          ./gradlew check -x integTest -x yamlRestTest
     - name: Upload Coverage Report
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-latest' && ${{ matrix.java }} == 17
       uses: codecov/codecov-action@v3
       with:
         file: ./build/reports/jacoco/test/jacocoTestReport.xml
+  integTest:
+    if: github.repository == 'opensearch-project/opensearch-ai-flow-framework'
+    needs: [spotless, javadoc]
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        java: [11, 17, 20]
+    name: Integ Test JDK${{ matrix.java }}, ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ matrix.java }}
+        distribution: temurin
+    - name: Build and Run Tests
+      run: |
+          ./gradlew integTest yamlRestTest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,12 +9,14 @@ on:
 
 jobs:
   spotless:
+    if: github.repository == 'opensearch-project/opensearch-ai-flow-framework'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Spotless Check
         run: ./gradlew spotlessCheck
   javadoc:
+    if: github.repository == 'opensearch-project/opensearch-ai-flow-framework'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,12 +25,15 @@ jobs:
       - name: Javadoc Check
         run: ./gradlew javadoc
   build:
-    if: github.repository == 'opensearch-project/opensearch-ai-flow-framework'
     needs: [spotless, javadoc]
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [11, 17, 20]
+        java: [11, 20]
+        include:
+          - os: ubuntu-latest
+            java: 17
+            codecov: yes
     name: Test JDK${{ matrix.java }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -42,17 +47,19 @@ jobs:
       run: |
           ./gradlew check -x integTest -x yamlRestTest
     - name: Upload Coverage Report
-      if: matrix.os == 'ubuntu-latest' && ${{ matrix.java }} == 17
+      if: ${{ matrix.codecov }}
       uses: codecov/codecov-action@v3
       with:
         file: ./build/reports/jacoco/test/jacocoTestReport.xml
   integTest:
-    if: github.repository == 'opensearch-project/opensearch-ai-flow-framework'
     needs: [spotless, javadoc]
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [11, 17, 20]
+        java: [11, 20]
+        include:
+          - os: ubuntu-latest
+            java: 17
     name: Integ Test JDK${{ matrix.java }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
### Description

Inspired by discussion on #84 (Thanks @owaiskazi19)

1. ~Removes the repo conditional on spotless and javadoc checks, so you don't need to submit the PR to get alerted about those failures.~
2. Separates the integTest and yamlRestTest tasks into a separate job that runs in parallel with the remaining gradle checks.  Right now they both take about the same time to complete.  If Integ tests start growing longer we can split these two out further.
3. Adds more JDKs to the build matrix.  **Note: I think 3 JDKs on 3 OS's for both test and integ is probably too much, probably should reduce them.**

![image](https://github.com/opensearch-project/opensearch-ai-flow-framework/assets/9291703/df1c2975-6461-42e2-98fc-52b3f12f0d14)

![image](https://github.com/opensearch-project/opensearch-ai-flow-framework/assets/9291703/b8997464-a5dc-44c7-b679-aabc4384616a)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
