### PR TITLE
Fixing ProvisionWorkflowTransportAction, handling case in which a document does not exist

### DIFF
--- a/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
+++ b/src/main/java/org/opensearch/flowframework/transport/ProvisionWorkflowTransportAction.java
@@ -84,6 +84,16 @@ public class ProvisionWorkflowTransportAction extends HandledTransportAction<Wor
             client.get(getRequest, ActionListener.wrap(response -> {
                 context.restore();
 
+                if (!response.isExists()) {
+                    listener.onFailure(
+                        new FlowFrameworkException(
+                            "Failed to retrieve template (" + workflowId + ") from global context.",
+                            RestStatus.NOT_FOUND
+                        )
+                    );
+                    return;
+                }
+
                 // Parse template from document source
                 Template template = Template.parseFromDocumentSource(response.getSourceAsString());
 


### PR DESCRIPTION
### Description
Fixing bug, handling case in which a GC entry does not exist prior to attempting to parse the use case template document from the response source

### Issues Resolved
Part of #88 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
