### PR TITLE
Put plugin API behind a feature flag

### DIFF
--- a/src/main/java/org/opensearch/flowframework/common/FlowFrameworkFeatureEnabledSetting.java
+++ b/src/main/java/org/opensearch/flowframework/common/FlowFrameworkFeatureEnabledSetting.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.common;
+
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+
+/**
+ * Controls enabling or disabling features of this plugin
+ */
+public class FlowFrameworkFeatureEnabledSetting {
+
+    /** This setting enables/disables the Flow Framework REST API */
+    public static final Setting<Boolean> FLOW_FRAMEWORK_ENABLED = Setting.boolSetting(
+        "plugins.flow_framework.enabled",
+        false,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    private volatile Boolean isFlowFrameworkEnabled;
+
+    /**
+     * Instantiate this class.
+     *
+     * @param clusterService OpenSearch cluster service
+     * @param settings OpenSearch settings
+     */
+    public FlowFrameworkFeatureEnabledSetting(ClusterService clusterService, Settings settings) {
+        // Currently this is just an on/off switch for the entire plugin's API.
+        // If desired more fine-tuned feature settings can be added below.
+        isFlowFrameworkEnabled = FLOW_FRAMEWORK_ENABLED.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(FLOW_FRAMEWORK_ENABLED, it -> isFlowFrameworkEnabled = it);
+    }
+
+    /**
+    * Whether the flow framework feature is enabled. If disabled, no REST APIs will be availble.
+    * @return whether Flow Framework is enabled.
+    */
+    public boolean isFlowFrameworkEnabled() {
+        return isFlowFrameworkEnabled;
+    }
+}

--- a/src/test/java/org/opensearch/flowframework/FlowFrameworkPluginTests.java
+++ b/src/test/java/org/opensearch/flowframework/FlowFrameworkPluginTests.java
@@ -11,13 +11,21 @@ package org.opensearch.flowframework;
 import org.opensearch.client.AdminClient;
 import org.opensearch.client.Client;
 import org.opensearch.client.ClusterAdminClient;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.env.Environment;
+import org.opensearch.flowframework.common.FlowFrameworkFeatureEnabledSetting;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -31,6 +39,9 @@ public class FlowFrameworkPluginTests extends OpenSearchTestCase {
     private ClusterAdminClient clusterAdminClient;
     private ThreadPool threadPool;
     private Settings settings;
+    private Environment environment;
+    private ClusterSettings clusterSettings;
+    private ClusterService clusterService;
 
     @Override
     public void setUp() throws Exception {
@@ -41,7 +52,18 @@ public class FlowFrameworkPluginTests extends OpenSearchTestCase {
         when(client.admin()).thenReturn(adminClient);
         when(adminClient.cluster()).thenReturn(clusterAdminClient);
         threadPool = new TestThreadPool(FlowFrameworkPluginTests.class.getName());
-        settings = Settings.EMPTY;
+
+        environment = mock(Environment.class);
+        settings = Settings.builder().build();
+        when(environment.settings()).thenReturn(settings);
+
+        final Set<Setting<?>> settingsSet = Stream.concat(
+            ClusterSettings.BUILT_IN_CLUSTER_SETTINGS.stream(),
+            Stream.of(FlowFrameworkFeatureEnabledSetting.FLOW_FRAMEWORK_ENABLED)
+        ).collect(Collectors.toSet());
+        clusterSettings = new ClusterSettings(settings, settingsSet);
+        clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
     }
 
     @Override
@@ -52,10 +74,14 @@ public class FlowFrameworkPluginTests extends OpenSearchTestCase {
 
     public void testPlugin() throws IOException {
         try (FlowFrameworkPlugin ffp = new FlowFrameworkPlugin()) {
-            assertEquals(3, ffp.createComponents(client, null, threadPool, null, null, null, null, null, null, null, null).size());
+            assertEquals(
+                3,
+                ffp.createComponents(client, clusterService, threadPool, null, null, null, environment, null, null, null, null).size()
+            );
             assertEquals(2, ffp.getRestHandlers(null, null, null, null, null, null, null).size());
             assertEquals(2, ffp.getActions().size());
             assertEquals(1, ffp.getExecutorBuilders(settings).size());
+            assertEquals(1, ffp.getSettings().size());
         }
     }
 }

--- a/src/test/java/org/opensearch/flowframework/common/FlowFrameworkFeatureEnabledSettingTests.java
+++ b/src/test/java/org/opensearch/flowframework/common/FlowFrameworkFeatureEnabledSettingTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.flowframework.common;
+
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FlowFrameworkFeatureEnabledSettingTests extends OpenSearchTestCase {
+
+    private Settings settings;
+    private ClusterSettings clusterSettings;
+    private ClusterService clusterService;
+
+    private FlowFrameworkFeatureEnabledSetting flowFrameworkFeatureEnabledSetting;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        settings = Settings.builder().build();
+        final Set<Setting<?>> settingsSet = Stream.concat(
+            ClusterSettings.BUILT_IN_CLUSTER_SETTINGS.stream(),
+            Stream.of(FlowFrameworkFeatureEnabledSetting.FLOW_FRAMEWORK_ENABLED)
+        ).collect(Collectors.toSet());
+        clusterSettings = new ClusterSettings(settings, settingsSet);
+        clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        flowFrameworkFeatureEnabledSetting = new FlowFrameworkFeatureEnabledSetting(clusterService, settings);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    public void testSettings() throws IOException {
+        assertFalse(flowFrameworkFeatureEnabledSetting.isFlowFrameworkEnabled());
+    }
+}

--- a/src/test/java/org/opensearch/flowframework/rest/RestCreateWorkflowActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestCreateWorkflowActionTests.java
@@ -14,6 +14,7 @@ import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.flowframework.TestHelpers;
+import org.opensearch.flowframework.common.FlowFrameworkFeatureEnabledSetting;
 import org.opensearch.flowframework.model.Template;
 import org.opensearch.flowframework.model.Workflow;
 import org.opensearch.flowframework.model.WorkflowEdge;
@@ -30,6 +31,7 @@ import java.util.Map;
 
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class RestCreateWorkflowActionTests extends OpenSearchTestCase {
 
@@ -42,6 +44,8 @@ public class RestCreateWorkflowActionTests extends OpenSearchTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
+        FlowFrameworkFeatureEnabledSetting flowFrameworkFeatureEnabledSetting = mock(FlowFrameworkFeatureEnabledSetting.class);
+        when(flowFrameworkFeatureEnabledSetting.isFlowFrameworkEnabled()).thenReturn(true);
 
         Version templateVersion = Version.fromString("1.0.0");
         List<Version> compatibilityVersions = List.of(Version.fromString("2.0.0"), Version.fromString("3.0.0"));
@@ -64,7 +68,7 @@ public class RestCreateWorkflowActionTests extends OpenSearchTestCase {
 
         // Invalid template configuration, wrong field name
         this.invalidTemplate = template.toJson().replace("use_case", "invalid");
-        this.createWorkflowRestAction = new RestCreateWorkflowAction();
+        this.createWorkflowRestAction = new RestCreateWorkflowAction(flowFrameworkFeatureEnabledSetting);
         this.createWorkflowPath = String.format(Locale.ROOT, "%s", WORKFLOW_URI);
         this.updateWorkflowPath = String.format(Locale.ROOT, "%s/{%s}", WORKFLOW_URI, "workflow_id");
         this.nodeClient = mock(NodeClient.class);

--- a/src/test/java/org/opensearch/flowframework/rest/RestProvisionWorkflowActionTests.java
+++ b/src/test/java/org/opensearch/flowframework/rest/RestProvisionWorkflowActionTests.java
@@ -12,6 +12,7 @@ import org.opensearch.client.node.NodeClient;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.flowframework.common.FlowFrameworkFeatureEnabledSetting;
 import org.opensearch.rest.RestHandler.Route;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.test.OpenSearchTestCase;
@@ -23,6 +24,7 @@ import java.util.Locale;
 
 import static org.opensearch.flowframework.common.CommonValue.WORKFLOW_URI;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class RestProvisionWorkflowActionTests extends OpenSearchTestCase {
 
@@ -33,7 +35,10 @@ public class RestProvisionWorkflowActionTests extends OpenSearchTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        this.provisionWorkflowRestAction = new RestProvisionWorkflowAction();
+        FlowFrameworkFeatureEnabledSetting flowFrameworkFeatureEnabledSetting = mock(FlowFrameworkFeatureEnabledSetting.class);
+        when(flowFrameworkFeatureEnabledSetting.isFlowFrameworkEnabled()).thenReturn(true);
+
+        this.provisionWorkflowRestAction = new RestProvisionWorkflowAction(flowFrameworkFeatureEnabledSetting);
         this.provisionWorkflowPath = String.format(Locale.ROOT, "%s/{%s}/%s", WORKFLOW_URI, "workflow_id", "_provision");
         this.nodeClient = mock(NodeClient.class);
     }


### PR DESCRIPTION
### Description

Requires an OpenSearch cluster setting to be enabled to use REST API.  

Follows similar model as AD and ML Commons.

### Issues Resolved

Fixes #141 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
