### PR TITLE
Ignore git diff errors when there's no origin branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -228,13 +228,11 @@ task updateVersion {
 ext.createDiffFile = { ->
     def file = Files.createTempFile(URLEncoder.encode(project.name, 'UTF-8'), '.diff').toFile()
     def diffBase = 'refs/remotes/origin/main'
-    // Only run locally
-    if (!System.getenv('CI')) {
-        file.withOutputStream { out ->
-            exec {
-                commandLine 'git', 'diff', '--no-color', '--minimal', diffBase
-                standardOutput = out
-            }
+    file.withOutputStream { out ->
+        exec {
+            ignoreExitValue true
+            commandLine 'git', 'diff', '--no-color', '--minimal', diffBase
+            standardOutput = out
         }
     }
     return file
@@ -242,7 +240,10 @@ ext.createDiffFile = { ->
 
 diffCoverageReport {
     afterEvaluate {
-        diffSource.file = createDiffFile()
+        // For local runs, ignore this on GitHub Actions
+        if (!System.getenv('CI')) {
+            diffSource.file = createDiffFile()
+        }
     }
 
     // View report at build/reports/jacoco/diffCoverage/html/index.html


### PR DESCRIPTION
### Description

The `git diff` command used for local code coverage reports fails when there is no `origin` to diff against.  This ignores the return value which may occur on build environments. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
