### PR TITLE
Force newer version of transitive (spotless) eclipse dependency

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # Spotless requires JDK 17+
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: temurin
       - name: Spotless Check
         run: ./gradlew spotlessCheck
   javadoc:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,7 +51,7 @@ jobs:
         distribution: temurin
     - name: Build and Run Tests
       run: |
-          ./gradlew check -x integTest -x yamlRestTest
+          ./gradlew check -x integTest -x yamlRestTest -x spotlessJava
     - name: Upload Coverage Report
       if: ${{ matrix.codecov }}
       uses: codecov/codecov-action@v3

--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,7 @@ dependencies {
     configurations.all {
         resolutionStrategy {
             force("com.google.guava:guava:32.1.3-jre") // CVE for 31.1
+            force("org.eclipse.platform:org.eclipse.core.runtime:3.29.0") // CVE for 3.26.100
         }
     }
 }


### PR DESCRIPTION
### Description

Spotless brings in a transitive dependency on a CVE-impacted Eclipse Core dependency.  This forces the newest version.

The non-impacted Eclipse dependency requires JDK17+ so I've also updated CI to use JDK17 for the spotless check and remove the spotless check from the subsequent build (allowing it to run on JDK11).

### Issues Resolved

Resolves #160 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
